### PR TITLE
Adding maxWidth variable that adds wrapper, retains original max width/height

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -1,46 +1,34 @@
 /*global jQuery */
+/*jshint browser:true */
 /*!
-* FitVids 1.0
+* FitVids 1.1
 *
-* Copyright 2011, Chris Coyier - http://css-tricks.com + Dave Rupert - http://daverupert.com
+* Copyright 2013, Chris Coyier - http://css-tricks.com + Dave Rupert - http://daverupert.com
 * Credit to Thierry Koblentz - http://www.alistapart.com/articles/creating-intrinsic-ratios-for-video/
 * Released under the WTFPL license - http://sam.zoy.org/wtfpl/
 *
-* Date: Thu Sept 01 18:00:00 2011 -0500
 */
 
-(function( $ ){
+;(function( $ ){
+
+  'use strict';
 
   $.fn.fitVids = function( options ) {
     var settings = {
       customSelector: null,
-      maxWidth: false,
+      ignore: null,
+      maxWidth: false, 
       maxWidthDefault: 900
+    };
+
+    if(!document.getElementById('fit-vids-style')) {
+      // appendStyles: https://github.com/toddmotto/fluidvids/blob/master/dist/fluidvids.js
+      var head = document.head || document.getElementsByTagName('head')[0];
+      var css = '.fluid-width-video-wrapper{width:100%;position:relative;padding:0;}.fluid-width-video-wrapper iframe,.fluid-width-video-wrapper object,.fluid-width-video-wrapper embed {position:absolute;top:0;left:0;width:100%;height:100%;}';
+      var div = document.createElement("div");
+      div.innerHTML = '<p>x</p><style id="fit-vids-style">' + css + '</style>';
+      head.appendChild(div.childNodes[1]);
     }
-
-    var div = document.createElement('div'),
-        ref = document.getElementsByTagName('base')[0] || document.getElementsByTagName('script')[0];
-
-  	div.className = 'fit-vids-style';
-    div.innerHTML = '&shy;<style>         \
-      .fluid-width-video-wrapper {        \
-         width: 100%;                     \
-         position: relative;              \
-         padding: 0;                      \
-      }                                   \
-                                          \
-      .fluid-width-video-wrapper iframe,  \
-      .fluid-width-video-wrapper object,  \
-      .fluid-width-video-wrapper embed {  \
-         position: absolute;              \
-         top: 0;                          \
-         left: 0;                         \
-         width: 100%;                     \
-         height: 100%;                    \
-      }                                   \
-    </style>';
-
-    ref.parentNode.insertBefore(div,ref);
 
     if ( options ) {
       $.extend( settings, options );
@@ -48,36 +36,53 @@
 
     return this.each(function(){
       var selectors = [
-        "iframe[src^='http://player.vimeo.com']",
-        "iframe[src^='http://www.youtube.com']",
-        "iframe[src^='http://www.kickstarter.com']",
-        "object",
-        "embed"
+        'iframe[src*="player.vimeo.com"]',
+        'iframe[src*="youtube.com"]',
+        'iframe[src*="youtube-nocookie.com"]',
+        'iframe[src*="kickstarter.com"][src*="video.html"]',
+        'object',
+        'embed'
       ];
 
       if (settings.customSelector) {
         selectors.push(settings.customSelector);
       }
 
+      var ignoreList = '.fitvidsignore';
+
+      if(settings.ignore) {
+        ignoreList = ignoreList + ', ' + settings.ignore;
+      }
+
       var $allVideos = $(this).find(selectors.join(','));
+      $allVideos = $allVideos.not('object object'); // SwfObj conflict patch
+      $allVideos = $allVideos.not(ignoreList); // Disable FitVids on this video.
 
       $allVideos.each(function(){
         var $this = $(this);
-        if (this.tagName.toLowerCase() == 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
-        var height = this.tagName.toLowerCase() == 'object' ? $this.attr('height') : $this.height(),
-            aspectRatio = height / $this.width();
-
-        var originalWidth = $this.attr('width');
-
-        $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
-
-        if (settings.maxWidth && (originalWidth || settings.maxWidthDefault)) {
-          $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper"></div>').parent('.max-width-video-wrapper').css('max-width', originalWidth ? originalWidth+"px" : settings.maxWidthDefault+"px");
+        if($this.parents(ignoreList).length > 0) {
+          return; // Disable FitVids on this video.
         }
-
+        if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
+        if ((!$this.css('height') && !$this.css('width')) && (isNaN($this.attr('height')) || isNaN($this.attr('width'))))
+        {
+          $this.attr('height', 9);
+          $this.attr('width', 16);
+        }
+        var height = ( this.tagName.toLowerCase() === 'object' || ($this.attr('height') && !isNaN(parseInt($this.attr('height'), 10))) ) ? parseInt($this.attr('height'), 10) : $this.height(),
+            width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
+            aspectRatio = height / width;
+        if(!$this.attr('id')){
+          var videoID = 'fitvid' + Math.floor(Math.random()*999999);
+          $this.attr('id', videoID);
+        }
+        $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100) + '%');
+        if (settings.maxWidth && (width || settings.maxWidthDefault)) {
+            $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper"></div>').parent('.max-width-video-wrapper').css('max-width', width ? width + "px" : settings.maxWidthDefault + "px");
+        }
         $this.removeAttr('height').removeAttr('width');
       });
     });
-
-  }
-})( jQuery );
+  };
+// Works with either jQuery or Zepto
+})( window.jQuery || window.Zepto );

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -72,7 +72,7 @@
         $this.wrap('<div class="fluid-width-video-wrapper" />').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
 
         if (settings.maxWidth) {
-          $('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper" />').parent('.max-width-video-wrapper').css('max-width', originalWidth + "px").css('max-height', originalHeight + "px");
+          $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper" />').parent('.max-width-video-wrapper').css('max-width', originalWidth + "px").css('max-height', originalHeight + "px");
         }
 
         $this.removeAttr('height').removeAttr('width');

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -72,7 +72,7 @@
         $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
 
         if (settings.maxWidth && (originalWidth || settings.maxWidthDefault)) {
-          $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper" />').parent('.max-width-video-wrapper').css('max-width', originalWidth ? originalWidth+"px" : settings.maxWidthDefault+"px");
+          $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper"></div>').parent('.max-width-video-wrapper').css('max-width', originalWidth ? originalWidth+"px" : settings.maxWidthDefault+"px");
         }
 
         $this.removeAttr('height').removeAttr('width');

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -14,7 +14,8 @@
   $.fn.fitVids = function( options ) {
     var settings = {
       customSelector: null,
-      maxWidth: false
+      maxWidth: false,
+      maxWidthDefault: 900
     }
 
     var div = document.createElement('div'),
@@ -68,10 +69,10 @@
 
         var originalWidth = $this.attr('width');
 
-        $this.wrap('<div class="fluid-width-video-wrapper" />').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
+        $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
 
-        if (settings.maxWidth && originalWidth) {
-          $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper" />').parent('.max-width-video-wrapper').css('max-width', originalWidth+"px");
+        if (settings.maxWidth && (originalWidth || settings.maxWidthDefault)) {
+          $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper" />').parent('.max-width-video-wrapper').css('max-width', originalWidth ? originalWidth+"px" : settings.maxWidthDefault+"px");
         }
 
         $this.removeAttr('height').removeAttr('width');

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -66,13 +66,12 @@
         var height = this.tagName.toLowerCase() == 'object' ? $this.attr('height') : $this.height(),
             aspectRatio = height / $this.width();
 
-        var originalWidth = $this.width(),
-            originalHeight = height;
+        var originalWidth = $this.attr('width');
 
         $this.wrap('<div class="fluid-width-video-wrapper" />').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
 
-        if (settings.maxWidth) {
-          $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper" />').parent('.max-width-video-wrapper').css('max-width', originalWidth + "px").css('max-height', originalHeight + "px");
+        if (settings.maxWidth && originalWidth) {
+          $this.parent('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper" />').parent('.max-width-video-wrapper').css('max-width', originalWidth+"px");
         }
 
         $this.removeAttr('height').removeAttr('width');

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -1,5 +1,5 @@
 /*global jQuery */
-/*! 
+/*!
 * FitVids 1.0
 *
 * Copyright 2011, Chris Coyier - http://css-tricks.com + Dave Rupert - http://daverupert.com
@@ -13,12 +13,13 @@
 
   $.fn.fitVids = function( options ) {
     var settings = {
-      customSelector: null
+      customSelector: null,
+      maxWidth: false
     }
-    
+
     var div = document.createElement('div'),
         ref = document.getElementsByTagName('base')[0] || document.getElementsByTagName('script')[0];
-        
+
   	div.className = 'fit-vids-style';
     div.innerHTML = '&shy;<style>         \
       .fluid-width-video-wrapper {        \
@@ -37,37 +38,46 @@
          height: 100%;                    \
       }                                   \
     </style>';
-                      
+
     ref.parentNode.insertBefore(div,ref);
-    
-    if ( options ) { 
+
+    if ( options ) {
       $.extend( settings, options );
     }
-    
+
     return this.each(function(){
       var selectors = [
-        "iframe[src^='http://player.vimeo.com']", 
-        "iframe[src^='http://www.youtube.com']", 
-        "iframe[src^='http://www.kickstarter.com']", 
-        "object", 
+        "iframe[src^='http://player.vimeo.com']",
+        "iframe[src^='http://www.youtube.com']",
+        "iframe[src^='http://www.kickstarter.com']",
+        "object",
         "embed"
       ];
-      
+
       if (settings.customSelector) {
         selectors.push(settings.customSelector);
       }
-      
+
       var $allVideos = $(this).find(selectors.join(','));
 
       $allVideos.each(function(){
         var $this = $(this);
-        if (this.tagName.toLowerCase() == 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; } 
+        if (this.tagName.toLowerCase() == 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
         var height = this.tagName.toLowerCase() == 'object' ? $this.attr('height') : $this.height(),
             aspectRatio = height / $this.width();
+
+        var originalWidth = $this.width(),
+            originalHeight = height;
+
         $this.wrap('<div class="fluid-width-video-wrapper" />').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
+
+        if (settings.maxWidth) {
+          $('.fluid-width-video-wrapper').wrap('<div class="max-width-video-wrapper" />').parent('.max-width-video-wrapper').css('max-width', originalWidth + "px").css('max-height', originalHeight + "px");
+        }
+
         $this.removeAttr('height').removeAttr('width');
       });
     });
-  
+
   }
 })( jQuery );


### PR DESCRIPTION
References issue #10. When the maxWidth option is set to true, an extra container is added that limits the size of the video to the originally-specified dimensions.

My text editor also strips out trailing whitespace, so there's a bunch of that removed as well :).

P.S. Chris, at WordCamp SF I totally ditched mid-talk upstairs to come and hear yours. It was awesome.
