### PR TITLE
Allow YouTube https:

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -48,6 +48,7 @@
       var selectors = [
         "iframe[src^='http://player.vimeo.com']", 
         "iframe[src^='http://www.youtube.com']", 
+        "iframe[src^='https://www.youtube.com']", 
         "iframe[src^='http://www.kickstarter.com']", 
         "object", 
         "embed"


### PR DESCRIPTION
FitVid was working great for Vimeo for me but wasn't working for YouTube, until I realized I had "Use HTTPS" checked when I was embedding YouTube videos. It's an edge case, but since it is one of the 4 embed options YouTube provides, I think it would be worth it to add a consideration for it.

Love the plugin, guys - thanks!
