### PR TITLE
Added native support for an additional variety of popular video players for enhanced tumblr/blog support:

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -49,9 +49,21 @@
         "iframe[src^='http://player.vimeo.com']", 
         "iframe[src^='http://www.youtube.com']", 
         "iframe[src^='https://www.youtube.com']", 
-        "iframe[src^='http://www.kickstarter.com']", 
+        "iframe[src^='http://www.kickstarter.com']",
+	"iframe[src^='http://www.funnyordie.com']",
+	"iframe[src^='http://media.mtvnservices.com']",
+	"iframe[src^='http://trailers.apple.com']",
+	"iframe[src^='http://www.brightcove.com']",
+	"iframe[src^='http://blip.tv']",
+	"iframe[src^='http://break.com']",
+	"iframe[src^='http://www.traileraddict.com']",
+	"iframe[src^='http://d.yimg.com']",
+	"iframe[src^='http://movies.yahoo.com']",
+	"iframe[src^='http://www.dailymotion.com']",
+	"iframe[src^='http://s.mcstatic.com']",
         "object", 
         "embed"
+
       ];
       
       if (settings.customSelector) {


### PR DESCRIPTION
 funny or die, apple trailers (still buggy but becomes fluid anyway), brightcove, blip, break, traileraddict, yahoo movies, dailymotion, metacafe, mtv video. It's important for blogs to have wide spectrum support across the board for a lot of video types since you don't know where you'll be blogging from or if you'll have control over video embeds. Tumblr is a good example due to its reblogging feature. I was running into that issue. Just thought I would tack on some more video players that aren't as common.
