### PR TITLE
Updated fitvid selector list to support https Vimeo player

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -47,6 +47,7 @@
     return this.each(function(){
       var selectors = [
         "iframe[src^='http://player.vimeo.com']", 
+        "iframe[src^='https://player.vimeo.com']", 
         "iframe[src^='http://www.youtube.com']", 
         "iframe[src^='https://www.youtube.com']", 
         "iframe[src^='http://www.kickstarter.com']", 


### PR DESCRIPTION
We needed to make this change to get Vimeo working with https and your plugin - seemed generic enough that others might want it as well. Thanks for the plugin!
