### PR TITLE
hide the fit-vids-style div so it doesn't affect other content

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -20,6 +20,7 @@
         ref = document.getElementsByTagName('base')[0] || document.getElementsByTagName('script')[0];
         
   	div.className = 'fit-vids-style';
+        div.style.display = 'none';
     div.innerHTML = '&shy;<style>         \
       .fluid-width-video-wrapper {        \
          width: 100%;                     \


### PR DESCRIPTION
The fit-vids-style div sometimes gets inserted in places that affect the display of other content on the page. If you set the display:none then the styles still get applied and everything works as expected. I tested in the latest versions of FF, Chrome and Safari.
