### PR TITLE
Skipping inner <object> tags with Firefox to avoid SwfObj conflict. (to ...

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -58,6 +58,7 @@
       }
       
       var $allVideos = $(this).find(selectors.join(','));
+      $allVideos = $allVideos.not("object object"); // SwfObj conflict patch
 
       $allVideos.each(function(){
         var $this = $(this);


### PR DESCRIPTION
...avoid wrapping with `<div>` nested `<object>` tags like `<object>...<object>...</object>...</object>`. This was already released in my http://themes.svn.wordpress.org/responsive/1.6.1/js-dev/jquery.fitvids.js Theme. Patch was proposed and sent to me by Oriol Arcas.
