### PR TITLE
Added YouTube privacy-enhanced mode support

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -47,7 +47,8 @@
     return this.each(function(){
       var selectors = [
         "iframe[src*='player.vimeo.com']", 
-        "iframe[src*='www.youtube.com']",  
+        "iframe[src*='www.youtube.com']",
+		"iframe[src*='www.youtube-nocookie.com']",
         "iframe[src*='www.kickstarter.com']", 
         "object", 
         "embed"


### PR DESCRIPTION
If you embedd a YouTube-video, there is the possibility to activate a privacy-enhanced mode. This mode uses youtube-nocookie.com instead of youtube.com. Because of this, FidVids.js wasn't working.
