### PR TITLE
Avoid videoID conflict

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -14,7 +14,9 @@
   $.fn.fitVids = function( options ) {
     var settings = {
       customSelector: null
-    }
+    };
+
+    var nVideoIDs = $('.fluid-width-video-wrapper').length;
     
     var div = document.createElement('div'),
         ref = document.getElementsByTagName('base')[0] || document.getElementsByTagName('script')[0];
@@ -65,8 +67,9 @@
         var height = this.tagName.toLowerCase() == 'object' ? $this.attr('height') : $this.height(),
             aspectRatio = height / $this.width();
 		if(!$this.attr('id')){
-			var videoID = 'fitvid' + Math.floor(Math.random()*999999);
-			$this.attr('id', videoID);
+			var videoID = 'fitvid' + nVideoIDs;
+      $this.attr('id', videoID);
+      nVideoIDs++;
 		}
         $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
         $this.removeAttr('height').removeAttr('width');


### PR DESCRIPTION
I'm not really sure what would you need a random videoID for, but I think there is a safer way to assign IDs to fitvids. So, instead of using a random number, we could count the fitvids within the page and use that number to generate IDs. That way we can avoid ID conflicts.

By the way, this is my first ever pull request! \o/
