### PR TITLE
Non-integer width or heigh values result in 0's

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -65,8 +65,8 @@
       $allVideos.each(function(){
         var $this = $(this);
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
-        var height = ( this.tagName.toLowerCase() === 'object' || $this.attr('height') ) ? parseInt($this.attr('height'), 10) : $this.height(),
-            width = $this.attr('width') ? parseInt($this.attr('width'), 10) : $this.width(),
+        var height = ( this.tagName.toLowerCase() === 'object' || ($this.attr('height') && !isNaN(parseInt($this.attr('height'), 10))) ? parseInt($this.attr('height'), 10) : $this.height(),
+            width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
             aspectRatio = height / width;
         if(!$this.attr('id')){
           var videoID = 'fitvid' + Math.floor(Math.random()*999999);


### PR DESCRIPTION
This doesn't _feel_ like a great solution, but here's the case I ran into:

Height was set to `auto` for the video containers, therefore when the checks were run to confirm that the values were set parseInt returned NaN and the video height was set to 0 in all cases.
