### PR TITLE
Add support for YouTube's 'privacy-enhanced' mode

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -51,6 +51,7 @@
       var selectors = [
         "iframe[src*='player.vimeo.com']",
         "iframe[src*='www.youtube.com']",
+        "iframe[src*='www.youtube-nocookie.com']",
         "iframe[src*='www.kickstarter.com']",
         "object",
         "embed"


### PR DESCRIPTION
YouTube now has a privacy-enhanced option which prevents cookies from being set unless an embedded video is played. All it actually does is replace `youtube.com` with `youtube-nocookies.com` in the iframe source and this commit just adds that domain to the selectors.
