### PR TITLE
Add vendor support for Wistia video

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -53,6 +53,7 @@
         "iframe[src*='www.youtube.com']",
         "iframe[src*='www.youtube-nocookie.com']",
         "iframe[src*='www.kickstarter.com']",
+        "iframe[src*='fast.wistia.net']",
         "object",
         "embed"
       ];

--- a/tests.html
+++ b/tests.html
@@ -52,6 +52,9 @@
         <div class="vendor">
           <iframe width="520px" height="391px" src="http://socialcam.com/videos/XRMP3Y5t/embed?utm_campaign=web&utm_source=embed" frameborder="0" allowfullscreen></iframe>
         </div>
+        <div class="vendor">
+          <iframe src="http://fast.wistia.net/embed/iframe/n4214gjbyl?controlsVisibleOnLoad=true&version=v1&videoHeight=360&videoWidth=640&volumeControl=true" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" width="640" height="360"></iframe>
+        </div>
       </div>
     
       <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>


### PR DESCRIPTION
While Wistia has it's own [responsive plugin](http://wistia.github.com/demobin/video-foam/), FitVids is really well known, and it would be cool for customers to be able to use both options (especially if they already have a FitVids implementation in place).

Will also add documentation on our side for the `customSelector`, but out-of-the-box support would be neat too :wink:

Added a test for review. Rock on!
