### PR TITLE
Mobile: Refresh video embed rendering on device orientation change.

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -76,6 +76,12 @@
         $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
         $this.removeAttr('height').removeAttr('width');
       });
+      
+      // refresh embed rendering on device orientation change
+      $(window).on('orientationchange', function() {
+        $allVideos.css('width','0%');
+        setTimeout(function() { $allVideos.css('width', '100%'); }, 130);
+      });
     });
   };
 })( jQuery );


### PR DESCRIPTION
Fixes bug when viewing a comedy central or TED video embed on mobile.

When you change orientation to landscape and back to portrait, the videos from those two services retain the portrait width, unless you reset the video width.
