### PR TITLE
Fixed issue #101 with Vimeo API and FidVids

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -72,6 +72,9 @@
         if(!$this.attr('id')){
           var videoID = 'fitvid' + Math.floor(Math.random()*999999);
           $this.attr('id', videoID);
+		   if ($this.attr('src').match('vimeo.com')){
+			$this.attr('src', $this.attr('src') + '&player_id=' + videoID);
+		  }
         }
         $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
         $this.removeAttr('height').removeAttr('width');


### PR DESCRIPTION
The problem is that FidVids inserts an id on the the given iframe, making the vimeo froogaloop js library stop working, hence the src needs the player_id param to work. I'm adding the player_id param to the vimeo src url, and making the froogaloop library to work as expected.

http://developer.vimeo.com/player/js-api
