### PR TITLE
Introduce a `maxAspectRatio` option to limit the height of the embedded video.

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -16,7 +16,8 @@
 
   $.fn.fitVids = function( options ) {
     var settings = {
-      customSelector: null
+      customSelector: null,
+      maxAspectRatio: 1.0 // e.g.: 0.75 for 4x3, 0.5625 for 16x9
     };
 
     var div = document.createElement('div'),
@@ -69,6 +70,9 @@
         var height = ( this.tagName.toLowerCase() === 'object' || ($this.attr('height') && !isNaN(parseInt($this.attr('height'), 10))) ) ? parseInt($this.attr('height'), 10) : $this.height(),
             width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
             aspectRatio = height / width;
+        if (aspectRatio > settings.maxAspectRatio) {
+          aspectRatio = settings.maxAspectRatio;
+        }
         if(!$this.attr('id')){
           var videoID = 'fitvid' + Math.floor(Math.random()*999999);
           $this.attr('id', videoID);


### PR DESCRIPTION
Allows the aspect ratio of the embedded video to be limited. For example,
if using:

```
$('.selector').fitVids({'maxAspectRatio': 0.5625});
```

Embedded videos encoded at aspect ratios "squarer" than 16x9 will be vertically
letterboxed, i.e.: displayed centred in the `.fluid-width-video-wrapper` with
black edges down the side.

My use case for this is a responsive gallery unit where I want images and videos to display at the same size (without having control of the videos that are displayed in it).  Without this option, fitvids embeds the videos at the width of the container x the native aspect ratio of the video. So 4x3 videos are much deeper than 16x9 videos.  With this option, I can constrain the 4x3 videos to display (centred, vertically letterboxed) within a 16x9 container.
