### PR TITLE
Fixed Issue #114: Set Default Width and Height when Width or Height are not numbers

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -73,6 +73,11 @@
       $allVideos.each(function(){
         var $this = $(this);
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
+        if (isNaN($this.attr('height')) || isNaN($this.attr('width')))
+        {
+          $this.attr('height', 9);
+          $this.attr('width', 16);
+        }
         var height = ( this.tagName.toLowerCase() === 'object' || ($this.attr('height') && !isNaN(parseInt($this.attr('height'), 10))) ) ? parseInt($this.attr('height'), 10) : $this.height(),
             width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
             aspectRatio = height / width;


### PR DESCRIPTION
[Fixed Issue #114](https://github.com/davatron5000/FitVids.js/issues/114)

> This Vimeo iframe causes the video to be displayed really tall with big black bars. I think it must have something to do with the mix of ints and percents and the aspect ratio calculation. Sorry, my JavaScript is not strong enough yet to be able to suggest a fix.

<pre><code>&lt;iframe src="http://player.vimeo.com/video/17914974" height="200" width="100%" allowfullscreen="" frameborder="0"&gt;&lt;/iframe&gt;</code></pre>


This fix checks the height and width values of the element. If either the height or width values are not a number (contain a percent sign) a default height of '9' pixels and default width of '16' pixels are applied to the corresponding attributes of that element.

[Example of Solution](http://kenhowardpdx.com/demos/fitvids-bug-114-fix/)
