### PR TITLE
remove check for 'object' in height var

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -58,7 +58,7 @@
       $allVideos.each(function(){
         var $this = $(this);
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
-        var height = ( this.tagName.toLowerCase() === 'object' || ($this.attr('height') && !isNaN(parseInt($this.attr('height'), 10))) ) ? parseInt($this.attr('height'), 10) : $this.height(),
+        var height = ( $this.attr('height') && !isNaN(parseInt($this.attr('height'), 10)) ) ? parseInt($this.attr('height'), 10) : $this.height(),
             width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
             aspectRatio = height / width;
         if(!$this.attr('id')){

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -58,7 +58,7 @@
       $allVideos.each(function(){
         var $this = $(this);
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
-        var height = ( $this.attr('height') && !isNaN(parseInt($this.attr('height'), 10)) ) ? parseInt($this.attr('height'), 10) : $this.height(),
+        var height = !isNaN(parseInt($this.attr('height'), 10)) ? parseInt($this.attr('height'), 10) : $this.height(),
             width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
             aspectRatio = height / width;
         if(!$this.attr('id')){


### PR DESCRIPTION
Check for 'object' is unnecessary, and should check for height attribute and proper value in height attribute regardless if object or not.
