### PR TITLE
FitVid modified for Kaltura dynamic embeds

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -16,7 +16,8 @@
 
   $.fn.fitVids = function( options ) {
     var settings = {
-      customSelector: null
+      customSelector: null,
+      replaceSelector: null,
     };
 
     if(!document.getElementById('fit-vids-style')) {
@@ -51,14 +52,16 @@
       if (settings.customSelector) {
         selectors.push(settings.customSelector);
       }
-
+      if( settings.replaceSelector ){
+      selectors = [ settings.replaceSelector ];  
+      }
       var $allVideos = $(this).find(selectors.join(','));
       $allVideos = $allVideos.not("object object"); // SwfObj conflict patch
       $allVideos.each(function(){
         var $this = $(this);
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length 
             || 
-          $this.attr('data-fitvids')
+          $this.attr('data-fitvid')
         ) { 
           return;
         }
@@ -69,7 +72,7 @@
           var videoID = 'fitvid' + Math.floor(Math.random()*999999);
           $this.attr('id', videoID);
         }
-        var $wrapper = $this.parent('.fluid-width-video-wrapper');
+        var $wrapper = $this.parents('.fluid-width-video-wrapper');
         if( $wrapper.length == 0 ){
           $wrapper = $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent();
         } 
@@ -81,7 +84,7 @@
           'width':'100%',
           'height':'100%'
         });
-        $this.attr('data-fitvids', 'done');
+        $this.attr('data-fitvid', 'done');
       });
     });
   };

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -23,7 +23,7 @@
 
       var div = document.createElement('div'),
           ref = document.getElementsByTagName('base')[0] || document.getElementsByTagName('script')[0],
-          cssStyles = '&shy;<style>.fluid-width-video-wrapper{width:100%;position:relative;padding:0;}.fluid-width-video-wrapper iframe,.fluid-width-video-wrapper object,.fluid-width-video-wrapper embed {position:absolute;top:0;left:0;width:100%;height:100%;}</style>';
+          cssStyles = '&shy;<style>.fluid-width-video-wrapper{width:100%;position:relative;padding:0;}</style>';
 
       div.className = 'fit-vids-style';
       div.id = 'fit-vids-style';
@@ -54,10 +54,14 @@
 
       var $allVideos = $(this).find(selectors.join(','));
       $allVideos = $allVideos.not("object object"); // SwfObj conflict patch
-
       $allVideos.each(function(){
         var $this = $(this);
-        if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
+        if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length 
+            || 
+          $this.attr('data-fitvids')
+        ) { 
+          return;
+        }
         var height = ( this.tagName.toLowerCase() === 'object' || ($this.attr('height') && !isNaN(parseInt($this.attr('height'), 10))) ) ? parseInt($this.attr('height'), 10) : $this.height(),
             width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
             aspectRatio = height / width;
@@ -65,8 +69,19 @@
           var videoID = 'fitvid' + Math.floor(Math.random()*999999);
           $this.attr('id', videoID);
         }
-        $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+"%");
-        $this.removeAttr('height').removeAttr('width');
+        var $wrapper = $this.parent('.fluid-width-video-wrapper');
+        if( $wrapper.length == 0 ){
+          $wrapper = $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent();
+        } 
+        $wrapper.css('padding-top', (aspectRatio * 100)+"%");
+        $this.removeAttr('height').removeAttr('width').css({
+          'position':'absolute',
+          'top':0,
+          'left':0,
+          'width':'100%',
+          'height':'100%'
+        });
+        $this.attr('data-fitvids', 'done');
       });
     });
   };


### PR DESCRIPTION
Change Summary: 
- no $(target).wrap() calls if not needed ( breaks instance reference of extended DOM objects )
- apply fill CSS directly to target ( not a CSS rule that breaks with rules against injected same domain iframe )
- use data attribute for fitvid applied flag, not parent selector
- select wrap against "parents" in cases embed target has DOM manipulations. 

I understand this may change the fundamentals too much, but a client requested compatibility so wanted to give you visibility on these changes. 

Kaltura dynamic embed works by embedding a 'a same domain iframe' this give us a lot more more control, ( synchronous api, parent page modification for pseudo fullscreen on iPads, IE, host page analytics etc. )  but fitvids's auto iframe selectors and .wrap calls break things a bit.  

Isolated test file here: 
http://player.kaltura.com/modules/KalturaSupport/tests/FitVids.html

If using kaltura's cross domain iframe based player things work in the normal way without modification.  
