### PR TITLE
Smaller width media resized to be 100% width causes unexpected styling

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -57,6 +57,7 @@
 
       $allVideos.each(function(){
         var $this = $(this);
+        if ($this.width() < 320) return false;
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
         var height = ( this.tagName.toLowerCase() === 'object' || ($this.attr('height') && !isNaN(parseInt($this.attr('height'), 10))) ) ? parseInt($this.attr('height'), 10) : $this.height(),
             width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),


### PR DESCRIPTION
I encountered the issue that required this fix when using the Wordpress Sermon Browser plugin. A media object is presented right next to the scripture, which shows 'listen'. This media object is less than 100 pixels in both width and height. However, the theme uses FitVids.js to make every media object 100% width which makes the listen obnoxiously large. This fixes this issue. 

![bfljqmlceaaiuax](https://f.cloud.github.com/assets/692663/2058750/5369e862-8b82-11e3-9d9f-aface5720c3d.png)

It makes sense to apply this fix across the board because one could assume that media which is set to be less than the smallest screen (iPhone width used here), shouldn't be 100% width on the desktop. [Would also like to have it so that FitVid.js only resizes down, attempted that in my org-max-size branch, but having issues with height.]
