### PR TITLE
Bower package name mismatch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "jquery.fitvids",
+  "name": "fitvids",
   "version": "1.1.0",
   "main": "./jquery.fitvids.js",
   "ignore": [


### PR DESCRIPTION
FitVids is registered as a Bower package with the name **fitvids**, but the name in bower.json file is **jquery.fitvids**. This causes issues with package recognition in software such as CodeKit—for example, see #169.

I propose changing the name in bower.json—though I’m not familiar enough with Bower to be sure that it won’t break something.

The alternative is to register the Bower package again with the name **jquery.fitvids**, as was originally suggested when the bower.json was added in #108.
