### PR TITLE
Add semi-colon before anonymous function

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -9,7 +9,7 @@
 *
 */
 
-(function( $ ){
+;(function( $ ){
 
   'use strict';
 


### PR DESCRIPTION
Placing a semi-colon before function invocation is a technique used to defense your code to break when it gets concatenated with other scripts that may not close properly. [The technique is also used in jQuery boilerplate](https://github.com/jquery-boilerplate/jquery-boilerplate/blob/686214e6f3372f11ff5912d4bfe5cb3bda4082e2/dist/jquery.boilerplate.js#L11), and is further explained [right here](http://stackoverflow.com/questions/7365172/semicolon-before-self-invoking-function).
