### PR TITLE
Added better way to assign iframe IDs

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -56,7 +56,7 @@
       $allVideos = $allVideos.not('object object'); // SwfObj conflict patch
       $allVideos = $allVideos.not(ignoreList); // Disable FitVids on this video.
 
-      $allVideos.each(function(){
+      $allVideos.each(function(count){
         var $this = $(this);
         if($this.parents(ignoreList).length > 0) {
           return; // Disable FitVids on this video.
@@ -71,7 +71,7 @@
             width = !isNaN(parseInt($this.attr('width'), 10)) ? parseInt($this.attr('width'), 10) : $this.width(),
             aspectRatio = height / width;
         if(!$this.attr('id')){
-          var videoID = 'fitvid' + Math.floor(Math.random()*999999);
+          var videoID = 'fitvid' + count);
           $this.attr('id', videoID);
         }
         $this.wrap('<div class="fluid-width-video-wrapper"></div>').parent('.fluid-width-video-wrapper').css('padding-top', (aspectRatio * 100)+'%');


### PR DESCRIPTION
Made more efficient by removing the Math.floor(Math.random()*999999) command
Eliminates risk of edge-case error where the same ID could potentially be created twice