### PR TITLE
Remove unnecessary JSHint global variable declaration

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -1,4 +1,3 @@
-/*global jQuery */
 /*jshint browser:true */
 /*!
 * FitVids 1.1


### PR DESCRIPTION
This JSHint variable declaration comment isn't needed, as we're referencing jQuery as `window.jQuery`. Instead, this actually threw an error because of it being an unused variable :)