### PR TITLE
Add UMD wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/bower_components

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -9,7 +9,20 @@
 *
 */
 
-;(function( $ ){
+!function(factory) {
+  if ("object" == typeof exports && "undefined" != typeof module) {
+    module.exports = factory;
+  }
+  else if ("function" == typeof define && define.amd) {
+    define(['jquery'], factory);
+  }
+  else {
+    var n;
+    "undefined" != typeof window ? n = window : "undefined" != typeof global ? n = global : "undefined" != typeof self && (n = self);
+    // Works with either jQuery or Zepto
+    factory(n.jQuery || n.Zepto);
+  }
+}(function( $ ){
 
   'use strict';
 
@@ -79,5 +92,4 @@
       });
     });
   };
-// Works with either jQuery or Zepto
-})( window.jQuery || window.Zepto );
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "fitvids",
+  "version": "1.1.0",
+  "description": "FitVids makes video embeds responsive",
+  "keywords": [
+    "FitVids",
+    "Responsive",
+    "RWD",
+    "YouTube",
+    "Vimeo"
+  ],
+  "license": "WTFPL",
+  "main": "jquery.fitvids.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {},
+  "devDependencies": {}
+}


### PR DESCRIPTION
Our team has gotten excellent mileage out of this little library, but have recently switched to [browserify](http://browserify.org/) as a build tool.  This little PR adds a UMD wrapper around the FitVids factory, such that it can be consumed in three different ways, all of which still allow your choice between jQuery or Zepto.

For `node` or CommonJS environments (such as browserify), it exports the factory itself, so that the choice of DOM library can be wired up manually:

``` javascript
var $ = require('jquery'); // or require('zepto');
require('fitvids')($);
```

For AMD environments (like [require.js](http://www.requirejs.org/)), you can just `require` FitVids and then go about your business, since it will wrap itself around whichever DOM library you shimmed in as `'jquery'`:

``` javascript
requirejs.config({
  paths: {
    fitvids: 'path/to/fitvids.js',
    jquery: 'path/to/jquery/or/zepto.js'
  }
});

require(['jquery', 'fitvids'], function ($) {
  // your code here
});
```

For those who like to live in the global namespace, that's cool too.  The UMD wrapper will recognize that and look for `window.jQuery` or `window.Zepto` as before.

I ran the `test.html` file, and everything performs as it originally did.  This PR should also get you very close to publishing on [npm](https://www.npmjs.com/) (short of actually running `npm publish .`).  That would be super dreamy!  :smile: 
