### PR TITLE
Fixed Width/Height attrs for percentage values

### DIFF
--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -61,7 +61,7 @@
           return; // Disable FitVids on this video.
         }
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
-        if( ( $this.css('width') && $this.css('width').indexOf("%") ) || ( $this.css('height') && $this.css('height').indexOf("%") ) ){
+        if( (( $this.css('width') && $this.css('width').indexOf("%") ) || ( $this.css('height') && $this.css('height').indexOf("%") )) == true ){
           $this.removeAttr('width').removeAttr('height');
         }
         if ((!$this.css('height') && !$this.css('width')) && (isNaN($this.attr('height')) || isNaN($this.attr('width'))))

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -61,7 +61,7 @@
           return; // Disable FitVids on this video.
         }
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
-        if( ( $this.css('width') && $this.attr('width').indexOf("%") ) || ( $this.css('height') && $this.attr('height').indexOf("%") ) ){
+        if( ( $this.css('width') && $this.css('width').indexOf("%") ) || ( $this.css('height') && $this.css('height').indexOf("%") ) ){
           $this.removeAttr('width').removeAttr('height');
         }
         if ((!$this.css('height') && !$this.css('width')) && (isNaN($this.attr('height')) || isNaN($this.attr('width'))))

--- a/jquery.fitvids.js
+++ b/jquery.fitvids.js
@@ -61,6 +61,9 @@
           return; // Disable FitVids on this video.
         }
         if (this.tagName.toLowerCase() === 'embed' && $this.parent('object').length || $this.parent('.fluid-width-video-wrapper').length) { return; }
+        if( ( $this.css('width') && $this.attr('width').indexOf("%") ) || ( $this.css('height') && $this.attr('height').indexOf("%") ) ){
+          $this.removeAttr('width').removeAttr('height');
+        }
         if ((!$this.css('height') && !$this.css('width')) && (isNaN($this.attr('height')) || isNaN($this.attr('width'))))
         {
           $this.attr('height', 9);


### PR DESCRIPTION
iFrame with percentage width/height values will be breaked because it converts values to int

<iframe src="https://www.youtube.com/embed/Cq2LcFozaPg?rel=0"
width="100%" height="396" frameborder="0"
allowfullscreen="allowfullscreen"></iframe>