### PR TITLE
docs: Fix simple typo, targetting -> targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ If you'd like to add a custom block to ignore FitVids, use the `ignore` option.
 ```
 
 ## Target Videos embedded without classes or containers 
-Customers/clients will occasionally add a video to a general content area or article and this may be without a class or container that you're targetting. A solution to this is to target the parent of videos, using something like the below;
+Customers/clients will occasionally add a video to a general content area or article and this may be without a class or container that you're targeting. A solution to this is to target the parent of videos, using something like the below;
 
 ```javascript
   $('iframe[src*="youtube"]').parent().fitVids();
   // You can change the selector to suit potential video providers, or chain them if your customer is likely to use more than one provider
 ```
 
-By targetting the iframe/embed parent you can then dynamically add in the fitVids special sauce on the fly without needing to know the container ahead of time.
+By targeting the iframe/embed parent you can then dynamically add in the fitVids special sauce on the fly without needing to know the container ahead of time.
 
 ## Known issues
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `targeting` rather than `targetting`.

